### PR TITLE
feat: add SOTA solution fields

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -310,11 +310,15 @@ def _row_from_generic_payload(payload, now):
         "outputs": payload.get("outputs", "") or "",
         "unit_tests": payload.get("unit_tests", "") or "",
         "solution": payload.get("solution") or payload.get("reference_solution") or "",
+        "sota_solution": payload.get("sota_solution", "") or "",
         "code_file": payload.get("code_file", "") or "",
         "language": payload.get("language"),
         "group": payload.get("group"),
         "time_complexity": payload.get("time_complexity", "") or "",
         "space_complexity": payload.get("space_complexity", "") or "",
+        "sota_time_complexity": payload.get("sota_time_complexity", "") or "",
+        "sota_space_complexity": payload.get("sota_space_complexity", "") or "",
+        "sota_correct": bool(payload.get("sota_correct", False)),
         "topics": _normalize_topics(payload.get("topics")),
         "difficulty": _normalize_difficulty(payload.get("difficulty")),
     }
@@ -356,17 +360,19 @@ def _normalize_snapshot_fields(snapshot: dict) -> dict:
     if "difficulty" in s:
         s["difficulty"] = _normalize_difficulty(s.get("difficulty"))
     # ensure string fields are not None
-    for k in ["prompt", "inputs", "outputs", "unit_tests", "solution",
-              "code_file", "time_complexity", "space_complexity", "notes"]:
+    for k in ["prompt", "inputs", "outputs", "unit_tests", "solution", "sota_solution",
+              "code_file", "time_complexity", "space_complexity", "sota_time_complexity", "sota_space_complexity", "notes"]:
         if k in s and s[k] is None:
             s[k] = ""
+    if "sota_correct" in s:
+        s["sota_correct"] = bool(s.get("sota_correct"))
     return s
 
 def _merge_meta_with_snapshot(existing_meta: dict, snapshot: dict) -> dict:
     merged = dict(existing_meta or {})
-    for k in TASK_KEYS:
-        if k in snapshot:
-            merged[k] = snapshot[k]
+    for k, v in (snapshot or {}).items():
+        if k not in ("notes",):
+            merged[k] = v
     return merged
 
 def _ensure_rows_updated(resp, table: str, match_info: dict):
@@ -388,8 +394,12 @@ def _snapshot_from_row(row: dict) -> dict:
         "code_file": meta.get("code_file", ""),
         "unit_tests": meta.get("unit_tests", ""),
         "solution": meta.get("solution", ""),
+        "sota_solution": meta.get("sota_solution", ""),
         "time_complexity": meta.get("time_complexity", ""),
         "space_complexity": meta.get("space_complexity", ""),
+        "sota_time_complexity": meta.get("sota_time_complexity", ""),
+        "sota_space_complexity": meta.get("sota_space_complexity", ""),
+        "sota_correct": meta.get("sota_correct", False),
         "topics": meta.get("topics", []),
         "difficulty": meta.get("difficulty", "Easy"),
         "notes": row.get("notes", "") or "",
@@ -1165,11 +1175,15 @@ def import_dataset_csv():
                     "outputs": r.get("outputs"),
                     "code_file": r.get("code_file"),
                     "reference_solution": r.get("reference_solution") or r.get("solution"),
+                    "sota_solution": r.get("sota_solution"),
                     "unit_tests": r.get("unit_tests"),
                     "difficulty": r.get("difficulty"),
                     "topics": r.get("topics"),
                     "time_complexity": r.get("time_complexity"),
                     "space_complexity": r.get("space_complexity"),
+                    "sota_time_complexity": r.get("sota_time_complexity"),
+                    "sota_space_complexity": r.get("sota_space_complexity"),
+                    "sota_correct": r.get("sota_correct"),
                     "notes": r.get("notes"),
                     "group": r.get("group"),
                     "lastRunSuccessful": False
@@ -1183,11 +1197,15 @@ def import_dataset_csv():
                 "code_file": payload.get("code_file"),
                 "reference_solution": payload.get("reference_solution"),
                 "solution": payload.get("solution"),
+                "sota_solution": payload.get("sota_solution"),
                 "unit_tests": payload.get("unit_tests"),
                 "difficulty": meta.get("difficulty", payload.get("difficulty")),
                 "topics": meta.get("topics", payload.get("topics")),
                 "time_complexity": meta.get("time_complexity", payload.get("time_complexity")),
                 "space_complexity": meta.get("space_complexity", payload.get("space_complexity")),
+                "sota_time_complexity": meta.get("sota_time_complexity", payload.get("sota_time_complexity")),
+                "sota_space_complexity": meta.get("sota_space_complexity", payload.get("sota_space_complexity")),
+                "sota_correct": meta.get("sota_correct", payload.get("sota_correct")),
                 "group": payload.get("group"),
                 "notes": payload.get("notes", r.get("notes") or ""),
                 "lastRunSuccessful": bool(payload.get("lastRunSuccessful", False)),
@@ -1255,11 +1273,15 @@ def import_dataset_jsonl():
                 "code_file": obj.get("code_file"),
                 "reference_solution": obj.get("reference_solution"),
                 "solution": obj.get("solution"),
+                "sota_solution": obj.get("sota_solution"),
                 "unit_tests": obj.get("unit_tests"),
                 "difficulty": meta.get("difficulty", obj.get("difficulty")),
                 "topics": meta.get("topics", obj.get("topics")),
                 "time_complexity": meta.get("time_complexity", obj.get("time_complexity")),
                 "space_complexity": meta.get("space_complexity", obj.get("space_complexity")),
+                "sota_time_complexity": meta.get("sota_time_complexity", obj.get("sota_time_complexity")),
+                "sota_space_complexity": meta.get("sota_space_complexity", obj.get("sota_space_complexity")),
+                "sota_correct": meta.get("sota_correct", obj.get("sota_correct")),
                 "group": obj.get("group"),
                 "notes": obj.get("notes", ""),
                 "lastRunSuccessful": bool(obj.get("lastRunSuccessful", False)),

--- a/app/review/[id]/page.tsx
+++ b/app/review/[id]/page.tsx
@@ -30,7 +30,8 @@ export default function ReviewItemPage() {
     loading,
     saving,
     running,
-    testResult,
+    testResultRef,
+    testResultSota,
     newTopic, setNewTopic,
     hasUnsavedChanges,
     isSuggestingTopics,
@@ -48,6 +49,7 @@ export default function ReviewItemPage() {
     removeTopic,
     suggestTopics,
     clearSolutionComments,
+    clearSotaSolutionComments,
     clearTestComments,
     headStamped,
     headDisplay,
@@ -58,7 +60,7 @@ export default function ReviewItemPage() {
   // resize textareas when switching versions/items
   useLayoutEffect(() => {
     if (!item) return;
-    const ids = ["prompt", "inputs", "outputs", "notes", "time_complexity", "space_complexity"];
+    const ids = ["prompt", "inputs", "outputs", "notes", "time_complexity", "space_complexity", "sota_time_complexity", "sota_space_complexity"];
     ids.forEach(k => {
       const el = document.getElementById(k) as HTMLTextAreaElement | null;
       if (el) resizeTextarea(el);
@@ -127,26 +129,39 @@ export default function ReviewItemPage() {
 
         <TestExecutionPanel
           lastRunSuccessful={!!item.lastRunSuccessful}
+          sotaCorrect={item.sota_correct}
           running={running}
           onRun={runTests}
-          testResult={testResult}
+          testResultRef={testResultRef}
+          testResultSota={testResultSota}
           copyPayload={{
             prompt: item.prompt ?? "",
             inputs: item.inputs ?? "",
             outputs: item.outputs ?? "",
             solution: item.solution ?? "",
-            unit_tests: item.unit_tests ?? ""
+            unit_tests: item.unit_tests ?? "",
+            sota_solution: item.sota_solution ?? ""
           }}
         />
 
-        <CodeEditorPanel
-          title="Solution Code"
-          code={item.solution ?? ""}
-          onChange={code => updateItem({ solution: code })}
-          onClear={clearSolutionComments}
-          clearDisabled={!(item.solution ?? "")}
-          placeholder="def solution(): ..."
-        />
+        <div className="grid grid-rows-2 overflow-hidden">
+          <CodeEditorPanel
+            title="SOTA Solution"
+            code={item.sota_solution ?? ""}
+            onChange={code => updateItem({ sota_solution: code })}
+            onClear={clearSotaSolutionComments}
+            clearDisabled={!(item.sota_solution ?? "")}
+            placeholder="def solution(): ..."
+          />
+          <CodeEditorPanel
+            title="Reference Solution"
+            code={item.solution ?? ""}
+            onChange={code => updateItem({ solution: code })}
+            onClear={clearSolutionComments}
+            clearDisabled={!(item.solution ?? "")}
+            placeholder="def solution(): ..."
+          />
+        </div>
 
         <CodeEditorPanel
           title="Unit Tests"

--- a/components/ItemForm.tsx
+++ b/components/ItemForm.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
 import TopicsEditor from "@/components/TopicsEditor";
 import { DatasetItem } from "@/components/types";
 
@@ -142,6 +143,34 @@ export default function ItemForm({
             onInput={onAutoResize}
             className="resize-none overflow-y-hidden"
           />
+        </div>
+        <div>
+          <Label htmlFor="sota_time_complexity">SOTA Time Complexity</Label>
+          <Textarea
+            key={`${item.id}-${selectedVersionId}-sota-time`}
+            id="sota_time_complexity"
+            value={v(item.sota_time_complexity)}
+            onChange={e => updateItem({ sota_time_complexity: e.target.value })}
+            placeholder="e.g., O(n log n)..."
+            onInput={onAutoResize}
+            className="resize-none overflow-y-hidden"
+          />
+        </div>
+        <div>
+          <Label htmlFor="sota_space_complexity">SOTA Space Complexity</Label>
+          <Textarea
+            key={`${item.id}-${selectedVersionId}-sota-space`}
+            id="sota_space_complexity"
+            value={v(item.sota_space_complexity)}
+            onChange={e => updateItem({ sota_space_complexity: e.target.value })}
+            placeholder="e.g., O(n)..."
+            onInput={onAutoResize}
+            className="resize-none overflow-y-hidden"
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox id="sota_correct" checked={item.sota_correct} onCheckedChange={checked => updateItem({ sota_correct: !!checked })} />
+          <Label htmlFor="sota_correct">SOTA Correct</Label>
         </div>
         <div>
           <Label>Topics</Label>

--- a/components/ReviewItemHooks.ts
+++ b/components/ReviewItemHooks.ts
@@ -21,7 +21,8 @@ export function useReviewItem(id: string, router: any) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
-  const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const [testResultRef, setTestResultRef] = useState<TestResult | null>(null);
+  const [testResultSota, setTestResultSota] = useState<TestResult | null>(null);
   const [newTopic, setNewTopic] = useState("");
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [isSuggestingTopics, setIsSuggestingTopics] = useState(false);
@@ -56,8 +57,12 @@ export function useReviewItem(id: string, router: any) {
         code_file: d.code_file ?? "",
         unit_tests: d.unit_tests ?? "",
         solution: d.solution ?? "",
+        sota_solution: d.sota_solution ?? "",
         time_complexity: d.time_complexity ?? "",
         space_complexity: d.space_complexity ?? "",
+        sota_time_complexity: d.sota_time_complexity ?? "",
+        sota_space_complexity: d.sota_space_complexity ?? "",
+        sota_correct: d.sota_correct ?? false,
         topics: Array.isArray(d.topics) ? (d.topics as string[]) : [],
         difficulty: (d.difficulty as any) || prev.difficulty,
         notes: d.notes ?? prev.notes ?? ""
@@ -248,8 +253,12 @@ export function useReviewItem(id: string, router: any) {
       code_file: item.code_file || "",
       unit_tests: item.unit_tests || "",
       solution: item.solution || "",
+      sota_solution: item.sota_solution || "",
       time_complexity: item.time_complexity || "",
       space_complexity: item.space_complexity || "",
+      sota_time_complexity: item.sota_time_complexity || "",
+      sota_space_complexity: item.sota_space_complexity || "",
+      sota_correct: item.sota_correct || false,
       topics: item.topics || [],
       difficulty: item.difficulty || "Easy",
       notes: item.notes || ""
@@ -301,16 +310,20 @@ export function useReviewItem(id: string, router: any) {
         prompt: item.prompt || "",
         inputs: item.inputs || "",
         outputs: item.outputs || "",
-        code_file: item.code_file || "",
-        unit_tests: item.unit_tests || "",
-        solution: item.solution || "",
-        time_complexity: item.time_complexity || "",
-        space_complexity: item.space_complexity || "",
-        topics: item.topics || [],
-        difficulty: item.difficulty || "Easy",
-        notes: item.notes || "",
-        lastRunSuccessful: item.lastRunSuccessful || false
-      };
+      code_file: item.code_file || "",
+      unit_tests: item.unit_tests || "",
+      solution: item.solution || "",
+      sota_solution: item.sota_solution || "",
+      time_complexity: item.time_complexity || "",
+      space_complexity: item.space_complexity || "",
+      sota_time_complexity: item.sota_time_complexity || "",
+      sota_space_complexity: item.sota_space_complexity || "",
+      sota_correct: item.sota_correct || false,
+      topics: item.topics || [],
+      difficulty: item.difficulty || "Easy",
+      notes: item.notes || "",
+      lastRunSuccessful: item.lastRunSuccessful || false
+    };
       const me = identity();
       await atomicSave(
         payload,
@@ -340,14 +353,20 @@ export function useReviewItem(id: string, router: any) {
   const runTests = async () => {
     if (!item) return;
     setRunning(true);
-    setTestResult(null);
-    const result = await runAutograder({ solution: item.solution, tests: item.unit_tests });
-    setTestResult(result as TestResult);
-    const updatedItem = { ...item, lastRunSuccessful: result.success };
+    setTestResultRef(null);
+    setTestResultSota(null);
+    let sotaRes: TestResult | null = null;
+    if (item.sota_solution) {
+      sotaRes = await runAutograder({ solution: item.sota_solution, tests: item.unit_tests }) as TestResult;
+      setTestResultSota(sotaRes);
+    }
+    const refRes = await runAutograder({ solution: item.solution, tests: item.unit_tests }) as TestResult;
+    setTestResultRef(refRes);
+    const updatedItem = { ...item, lastRunSuccessful: refRes.success, sota_correct: sotaRes ? sotaRes.success : item.sota_correct };
     setItem(updatedItem as DatasetItem);
     setHasUnsavedChanges(true);
     setRunning(false);
-    return result;
+    return { ref: refRes, sota: sotaRes };
 
     // try {
     //   const response = await fetch("/api/run-tests", {
@@ -377,9 +396,12 @@ export function useReviewItem(id: string, router: any) {
 
   const updateItem = (updates: Partial<DatasetItem>) => {
     if (!item) return;
-    const newUpdates: Partial<DatasetItem & { lastRunSuccessful: boolean }> = { ...updates };
+    const newUpdates: Partial<DatasetItem & { lastRunSuccessful: boolean; sota_correct: boolean }> = { ...updates };
     if ("solution" in updates || "unit_tests" in updates) {
       newUpdates.lastRunSuccessful = false;
+    }
+    if ("sota_solution" in updates || "unit_tests" in updates) {
+      newUpdates.sota_correct = false;
     }
     setItem(prev => (prev ? { ...prev, ...newUpdates } : null));
     setHasUnsavedChanges(true);
@@ -422,6 +444,12 @@ export function useReviewItem(id: string, router: any) {
     updateItem({ solution: cleaned });
   };
 
+  const clearSotaSolutionComments = () => {
+    if (!item) return;
+    const cleaned = clearCommentsAndDocstrings(item.sota_solution ?? "");
+    updateItem({ sota_solution: cleaned });
+  };
+
   const clearTestComments = () => {
     if (!item) return;
     const cleaned = clearCommentsAndDocstrings(item.unit_tests ?? "");
@@ -446,7 +474,8 @@ export function useReviewItem(id: string, router: any) {
     loading,
     saving,
     running,
-    testResult,
+    testResultRef,
+    testResultSota,
     newTopic, setNewTopic,
     hasUnsavedChanges,
     isSuggestingTopics,
@@ -486,8 +515,12 @@ export function useReviewItem(id: string, router: any) {
             code_file: item.code_file || "",
             unit_tests: item.unit_tests || "",
             solution: item.solution || "",
+            sota_solution: item.sota_solution || "",
             time_complexity: item.time_complexity || "",
             space_complexity: item.space_complexity || "",
+            sota_time_complexity: item.sota_time_complexity || "",
+            sota_space_complexity: item.sota_space_complexity || "",
+            sota_correct: item.sota_correct || false,
             topics: item.topics || [],
             difficulty: item.difficulty || "Easy",
             notes: item.notes || ""
@@ -521,6 +554,7 @@ export function useReviewItem(id: string, router: any) {
     removeTopic,
     suggestTopics,
     clearSolutionComments,
+    clearSotaSolutionComments,
     clearTestComments,
 
     // header derived

--- a/components/TestExecutionPanel.tsx
+++ b/components/TestExecutionPanel.tsx
@@ -19,27 +19,32 @@ interface CopyPayload {
   outputs: string
   solution?: string
   unit_tests?: string
+  sota_solution?: string
 }
 
 interface Props {
   lastRunSuccessful?: boolean
+  sotaCorrect?: boolean
   running: boolean
   onRun: () => void
   runDisabled?: boolean
-  testResult: TestResult | null
+  testResultRef: TestResult | null
+  testResultSota: TestResult | null
   /** Added: source text for the three copy actions */
   copyPayload?: CopyPayload
 }
 
 export default function TestExecutionPanel({
   lastRunSuccessful,
+  sotaCorrect,
   running,
   onRun,
   runDisabled,
-  testResult,
+  testResultRef,
+  testResultSota,
   copyPayload,
 }: Props) {
-  const [copied, setCopied] = useState<null | 'qio' | 'solution' | 'tests'>(null)
+  const [copied, setCopied] = useState<null | 'qio' | 'solution' | 'tests' | 'sota'>(null)
 
   const baseText = () => {
     const p = copyPayload?.prompt?.trim() ?? ''
@@ -52,9 +57,14 @@ export default function TestExecutionPanel({
     ].filter(Boolean).join('\n\n')
   }
 
-  const withSolution = () => {
+  const withRefSolution = () => {
     const s = copyPayload?.solution ?? ''
     return `${baseText()}\n\nSolution:\n\`\`\`\n${s}\n\`\`\``
+  }
+
+  const withSotaSolution = () => {
+    const s = copyPayload?.sota_solution ?? ''
+    return `${baseText()}\n\nSOTA Solution:\n\`\`\`\n${s}\n\`\`\``
   }
 
   const withTests = () => {
@@ -62,10 +72,11 @@ export default function TestExecutionPanel({
     return `${baseText()}\n\nTests:\n\`\`\`\n${t}\n\`\`\``
   }
 
-  const doCopy = async (kind: 'qio' | 'solution' | 'tests') => {
+  const doCopy = async (kind: 'qio' | 'solution' | 'tests' | 'sota') => {
     let text = ''
     if (kind === 'qio') text = baseText()
-    if (kind === 'solution') text = withSolution()
+    if (kind === 'solution') text = withRefSolution()
+    if (kind === 'sota') text = withSotaSolution()
     if (kind === 'tests') text = withTests()
 
     try {
@@ -83,16 +94,28 @@ export default function TestExecutionPanel({
         <div className="flex items-center justify-between">
           <CardTitle>Test Execution</CardTitle>
           <div className="flex items-center gap-2">
+            {sotaCorrect === true && (
+              <Badge variant="outline" className="text-green-600 border-green-600">
+                <CheckCircle className="w-3 h-3 mr-1" />
+                SOTA Pass
+              </Badge>
+            )}
+            {sotaCorrect === false && (
+              <Badge variant="outline" className="text-gray-600 border-gray-600">
+                <XCircle className="w-3 h-3 mr-1" />
+                SOTA Not Verified
+              </Badge>
+            )}
             {lastRunSuccessful === true && (
               <Badge variant="outline" className="text-green-600 border-green-600">
                 <CheckCircle className="w-3 h-3 mr-1" />
-                Tests Pass
+                Ref Pass
               </Badge>
             )}
             {lastRunSuccessful === false && (
               <Badge variant="outline" className="text-gray-600 border-gray-600">
                 <XCircle className="w-3 h-3 mr-1" />
-                Not Verified
+                Ref Not Verified
               </Badge>
             )}
           </div>
@@ -121,13 +144,29 @@ export default function TestExecutionPanel({
               type="button"
               size="sm"
               variant="outline"
-              className="whitespace-nowrap bg-green-50 text-green-700 border-green-200 hover:bg-green-100"
-              onClick={() => doCopy('solution')}
-              title="Copy with Solution (triple backticks)"
-              aria-label="Copy with Solution"
+              className="whitespace-nowrap bg-orange-50 text-orange-700 border-orange-200 hover:bg-orange-100"
+              onClick={() => doCopy('sota')}
+              title="Copy with SOTA Solution (triple backticks)"
+              aria-label="Copy with SOTA Solution"
             >
               <ClipboardCheck className="w-4 h-4 mr-1" />
-              Copy + Solution
+              Copy + SOTA
+              {copied === 'sota' && (
+                <Badge className="ml-2 bg-orange-600 text-white">Copied</Badge>
+              )}
+            </Button>
+
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="whitespace-nowrap bg-green-50 text-green-700 border-green-200 hover:bg-green-100"
+              onClick={() => doCopy('solution')}
+              title="Copy with Reference Solution (triple backticks)"
+              aria-label="Copy with Reference Solution"
+            >
+              <ClipboardCheck className="w-4 h-4 mr-1" />
+              Copy + Ref
               {copied === 'solution' && (
                 <Badge className="ml-2 bg-green-600 text-white">Copied</Badge>
               )}
@@ -169,34 +208,68 @@ export default function TestExecutionPanel({
       </CardHeader>
 
       <CardContent className="overflow-y-auto">
-        {testResult && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              {testResult.success ? (
-                <Badge className="bg-green-100 text-green-800">
-                  <CheckCircle className="w-3 h-3 mr-1" />
-                  Tests Passed
-                </Badge>
-              ) : (
-                <Badge className="bg-red-100 text-red-800">
-                  <XCircle className="w-3 h-3 mr-1" />
-                  Tests Failed
-                </Badge>
-              )}
-              {testResult.timeout && (
-                <Badge variant="outline" className="text-yellow-600 border-yellow-600">
-                  <Clock className="w-3 h-3 mr-1" />
-                  Timeout
-                </Badge>
-              )}
-            </div>
-            <div className="bg-gray-50 p-3 rounded-md">
-              <pre className="text-sm whitespace-pre-wrap">
-                {testResult.output || testResult.error || 'No output'}
-              </pre>
-            </div>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            {testResultSota && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  {testResultSota.success ? (
+                    <Badge className="bg-green-100 text-green-800">
+                      <CheckCircle className="w-3 h-3 mr-1" />
+                      Tests Passed
+                    </Badge>
+                  ) : (
+                    <Badge className="bg-red-100 text-red-800">
+                      <XCircle className="w-3 h-3 mr-1" />
+                      Tests Failed
+                    </Badge>
+                  )}
+                  {testResultSota.timeout && (
+                    <Badge variant="outline" className="text-yellow-600 border-yellow-600">
+                      <Clock className="w-3 h-3 mr-1" />
+                      Timeout
+                    </Badge>
+                  )}
+                </div>
+                <div className="bg-gray-50 p-3 rounded-md">
+                  <pre className="text-sm whitespace-pre-wrap">
+                    {testResultSota.output || testResultSota.error || 'No output'}
+                  </pre>
+                </div>
+              </div>
+            )}
           </div>
-        )}
+          <div>
+            {testResultRef && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  {testResultRef.success ? (
+                    <Badge className="bg-green-100 text-green-800">
+                      <CheckCircle className="w-3 h-3 mr-1" />
+                      Tests Passed
+                    </Badge>
+                  ) : (
+                    <Badge className="bg-red-100 text-red-800">
+                      <XCircle className="w-3 h-3 mr-1" />
+                      Tests Failed
+                    </Badge>
+                  )}
+                  {testResultRef.timeout && (
+                    <Badge variant="outline" className="text-yellow-600 border-yellow-600">
+                      <Clock className="w-3 h-3 mr-1" />
+                      Timeout
+                    </Badge>
+                  )}
+                </div>
+                <div className="bg-gray-50 p-3 rounded-md">
+                  <pre className="text-sm whitespace-pre-wrap">
+                    {testResultRef.output || testResultRef.error || 'No output'}
+                  </pre>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
       </CardContent>
     </Card>
   )

--- a/components/dashboard/useDatasetDashboard.ts
+++ b/components/dashboard/useDatasetDashboard.ts
@@ -37,14 +37,18 @@ const normalizeForCreate = (p: Partial<DatasetItem>): Partial<DatasetItem> => {
     outputs: String(p.outputs ?? ''),
     unit_tests: String(p.unit_tests ?? ''),
     solution: String(p.solution ?? ''),
+    sota_solution: String((p as any).sota_solution ?? ''),
     code_file: p.code_file ? String(p.code_file) : '',
     language: p.language ? String(p.language) : undefined,
     group: p.group === '' ? null : p.group ?? null,
     time_complexity: String(p.time_complexity ?? ''),
     space_complexity: String(p.space_complexity ?? ''),
+    sota_time_complexity: String((p as any).sota_time_complexity ?? ''),
+    sota_space_complexity: String((p as any).sota_space_complexity ?? ''),
     topics: toTopics(p.topics),
     difficulty: normDifficulty((p as any).difficulty),
-    notes: String(p.notes ?? '')
+    notes: String(p.notes ?? ''),
+    sota_correct: Boolean((p as any).sota_correct ?? false)
   }
 }
 
@@ -425,14 +429,19 @@ export function useDatasetDashboard() {
       outputs: o?.outputs || '',
       code_file: o?.code_file || '',
       solution: o?.reference_solution ?? o?.solution ?? '',
+      // SOTA solution lives in metadata; fall back to top-level for backwards compatibility
+      sota_solution: meta?.sota_solution || o?.sota_solution || '',
       unit_tests: o?.unit_tests || '',
       language: o?.language,
       difficulty: meta?.difficulty || o?.difficulty || 'Easy',
       topics: meta?.topics || o?.topics,
       time_complexity: meta?.time_complexity || o?.time_complexity || '',
       space_complexity: meta?.space_complexity || o?.space_complexity || '',
+      sota_time_complexity: meta?.sota_time_complexity || o?.sota_time_complexity || '',
+      sota_space_complexity: meta?.sota_space_complexity || o?.sota_space_complexity || '',
       notes: o?.notes || '',
-      group: o?.group ?? null
+      group: o?.group ?? null,
+      sota_correct: meta?.sota_correct ?? o?.sota_correct ?? false
     })
   }
 
@@ -450,14 +459,18 @@ export function useDatasetDashboard() {
       outputs: clean(row['outputs']),
       code_file: clean(row['code_file']),
       solution: clean(row['reference_solution'] || row['solution']),
+      sota_solution: clean(row['sota_solution']),
       unit_tests: clean(row['unit_tests']),
       language: clean(row['language']) || undefined,
       difficulty: normDifficulty(clean(row['difficulty'])),
       topics: toTopics(clean(row['topics'])),
       time_complexity: clean(row['time_complexity']),
       space_complexity: clean(row['space_complexity']),
+      sota_time_complexity: clean(row['sota_time_complexity']),
+      sota_space_complexity: clean(row['sota_space_complexity']),
       notes: clean(row['notes']),
-      group: row['group'] ? clean(row['group']) : null
+      group: row['group'] ? clean(row['group']) : null,
+      sota_correct: clean(row['sota_correct']) === 'true'
     })
   }
 

--- a/components/dataset-item-card.tsx
+++ b/components/dataset-item-card.tsx
@@ -47,12 +47,16 @@ export function DatasetItemCard({
       outputs: item.outputs,
       code_file: item.code_file,
       reference_solution: item.solution,
+      sota_solution: item.sota_solution,
       unit_tests: item.unit_tests,
       metadata: {
         difficulty: item.difficulty,
         topics: item.topics,
         time_complexity: item.time_complexity,
         space_complexity: item.space_complexity,
+        sota_time_complexity: item.sota_time_complexity,
+        sota_space_complexity: item.sota_space_complexity,
+        sota_correct: item.sota_correct,
       }
     }
     navigator.clipboard.writeText(JSON.stringify(obj, null, 2))

--- a/components/groups-section.tsx
+++ b/components/groups-section.tsx
@@ -66,12 +66,16 @@ export function GroupsSection({ items, activeGroup, onGroupChange }: GroupsSecti
       outputs: item.outputs,
       code_file: item.code_file,
       reference_solution: item.solution,
+      sota_solution: item.sota_solution,
       unit_tests: item.unit_tests,
       metadata: {
         difficulty: item.difficulty,
         topics: item.topics,
         time_complexity: item.time_complexity,
         space_complexity: item.space_complexity,
+        sota_time_complexity: item.sota_time_complexity,
+        sota_space_complexity: item.sota_space_complexity,
+        sota_correct: item.sota_correct,
       }
     }))
     const jsonl = transformed.map(obj => JSON.stringify(obj)).join('\n')

--- a/components/types.ts
+++ b/components/types.ts
@@ -5,11 +5,15 @@ export interface DatasetItem {
   outputs: string
   unit_tests: string
   solution: string
+  sota_solution: string
   code_file?: string
   language?: string
   group?: string | null
   time_complexity: string
   space_complexity: string
+  sota_time_complexity: string
+  sota_space_complexity: string
+  sota_correct: boolean
   topics: string[]
   difficulty: 'Easy' | 'Medium' | 'Hard'
   notes: string

--- a/components/utils.ts
+++ b/components/utils.ts
@@ -195,8 +195,8 @@ export const executeExport = (
 
   if (format === 'csv') {
     const csvHeaders = [
-      'id', 'language', 'prompt', 'inputs', 'outputs', 'code_file', 'reference_solution', 'unit_tests',
-      'difficulty', 'topics', 'time_complexity', 'space_complexity', 'notes',
+      'id', 'language', 'prompt', 'inputs', 'outputs', 'code_file', 'reference_solution', 'sota_solution', 'unit_tests',
+      'difficulty', 'topics', 'time_complexity', 'space_complexity', 'sota_time_complexity', 'sota_space_complexity', 'sota_correct', 'notes',
       'createdAt', 'updatedAt', 'lastRunSuccessful', 'group', 'full_task_json'
     ];
     const header = csvHeaders.join(',') + '\n';
@@ -209,12 +209,16 @@ export const executeExport = (
         outputs: item.outputs,
         code_file: item.code_file,
         reference_solution: item.solution,
+        sota_solution: item.sota_solution,
         unit_tests: item.unit_tests,
         metadata: {
           difficulty: item.difficulty,
           topics: item.topics,
           time_complexity: item.time_complexity,
           space_complexity: item.space_complexity,
+          sota_time_complexity: item.sota_time_complexity,
+          sota_space_complexity: item.sota_space_complexity,
+          sota_correct: item.sota_correct,
         }
       });
 
@@ -226,11 +230,15 @@ export const executeExport = (
         item.outputs,
         item.code_file,
         item.solution,
+        item.sota_solution,
         item.unit_tests,
         item.difficulty,
         item.topics,
         item.time_complexity,
         item.space_complexity,
+        item.sota_time_complexity,
+        item.sota_space_complexity,
+        item.sota_correct,
         item.notes,
         item.createdAt,
         item.updatedAt,
@@ -256,12 +264,16 @@ export const executeExport = (
       outputs: item.outputs,
       code_file: item.code_file,
       reference_solution: item.solution,
+      sota_solution: item.sota_solution,
       unit_tests: item.unit_tests,
       metadata: {
         difficulty: item.difficulty,
         topics: item.topics,
         time_complexity: item.time_complexity,
         space_complexity: item.space_complexity,
+        sota_time_complexity: item.sota_time_complexity,
+        sota_space_complexity: item.sota_space_complexity,
+        sota_correct: item.sota_correct,
       }
     }));
     dataStr = transformedData.map(item => JSON.stringify(item)).join('\n');
@@ -275,12 +287,16 @@ export const executeExport = (
       outputs: item.outputs,
       code_file: item.code_file,
       reference_solution: item.solution,
+      sota_solution: item.sota_solution,
       unit_tests: item.unit_tests,
       metadata: {
         difficulty: item.difficulty,
         topics: item.topics,
         time_complexity: item.time_complexity,
         space_complexity: item.space_complexity,
+        sota_time_complexity: item.sota_time_complexity,
+        sota_space_complexity: item.sota_space_complexity,
+        sota_correct: item.sota_correct,
       }
     }));
     dataStr = JSON.stringify(transformedData, null, 2);


### PR DESCRIPTION
## Summary
- add SOTA solution and metadata fields to dataset items and editor UIs
- support separate test execution and copying for SOTA vs reference solutions
- extend import/export and backend API to handle new SOTA fields
- load SOTA solution from metadata to avoid database schema changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to load config "next/typescript")*

------
https://chatgpt.com/codex/tasks/task_e_68b799990190833380265a7d203996c8