### PR TITLE
Add persistent authentication with refresh

### DIFF
--- a/components/auth-context.tsx
+++ b/components/auth-context.tsx
@@ -18,28 +18,82 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined)
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null)
+  const [refreshToken, setRefreshToken] = useState<string | null>(null)
+  const [expiresAt, setExpiresAt] = useState<number | null>(null)
   const [user, setUser] = useState<AuthUser | null>(null)
   const [status, setStatus] = useState<AuthStatus>('loading')
 
+  type RawSession = {
+    access_token: string | null
+    refresh_token: string | null
+    expires_in?: number | null
+    expires_at?: number | null
+  }
+
+  const persistSession = (session: RawSession) => {
+    const accessToken = session.access_token
+    if (!accessToken) return
+
+    const refresh = session.refresh_token
+    const expirySeconds = session.expires_at
+      ? Number(session.expires_at)
+      : session.expires_in
+        ? Math.round(Date.now() / 1000) + Number(session.expires_in)
+        : null
+
+    const expiryMs = expirySeconds ? expirySeconds * 1000 : null
+
+    setToken(accessToken)
+    setRefreshToken(refresh || null)
+    setExpiresAt(expiryMs)
+
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('auth:access_token', accessToken)
+      if (refresh) localStorage.setItem('auth:refresh_token', refresh)
+      else localStorage.removeItem('auth:refresh_token')
+      if (expiryMs) localStorage.setItem('auth:expires_at', String(expiryMs))
+      else localStorage.removeItem('auth:expires_at')
+    }
+  }
+
+  const loadStoredSession = (): RawSession | null => {
+    if (typeof window === 'undefined') return null
+    const access_token = localStorage.getItem('auth:access_token')
+    const refresh_token = localStorage.getItem('auth:refresh_token')
+    const expires_raw = localStorage.getItem('auth:expires_at')
+
+    const expires_at = expires_raw ? Number(expires_raw) / 1000 : null
+
+    if (!access_token) return null
+    return { access_token, refresh_token, expires_at }
+  }
+
   useEffect(() => {
-    const fromUrl = () => {
+    const fromUrl = (): RawSession | null => {
       if (typeof window === 'undefined') return null
-      const extract = (s: string) => {
-        const p = new URLSearchParams(s.startsWith('?') || s.startsWith('#') ? s.slice(1) : s)
-        return p.get('access_token')
-      }
-      const t = extract(window.location.hash) || extract(window.location.search)
-      if (t) {
+
+      const extract = (s: string) => new URLSearchParams(s.startsWith('?') || s.startsWith('#') ? s.slice(1) : s)
+      const searchParams = extract(window.location.search)
+      const hashParams = extract(window.location.hash)
+
+      const access_token = hashParams.get('access_token') || searchParams.get('access_token')
+      const refresh_token = hashParams.get('refresh_token') || searchParams.get('refresh_token')
+      const expires_in = Number(hashParams.get('expires_in') || searchParams.get('expires_in') || '') || null
+      const expires_at = Number(hashParams.get('expires_at') || searchParams.get('expires_at') || '') || null
+
+      if (access_token || refresh_token) {
         try {
           history.replaceState({}, document.title, window.location.pathname + window.location.search.split('?')[0])
         } catch {}
       }
-      return t
+
+      if (!access_token) return null
+      return { access_token, refresh_token, expires_in, expires_at }
     }
-    const t = fromUrl() || (typeof window !== 'undefined' ? localStorage.getItem('auth:access_token') : null)
-    if (t) {
-      setToken(t)
-      if (typeof window !== 'undefined') localStorage.setItem('auth:access_token', t)
+
+    const initialSession = fromUrl() || loadStoredSession()
+    if (initialSession) {
+      persistSession(initialSession)
     } else {
       setStatus('unauthenticated')
     }
@@ -48,6 +102,48 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const verify = async () => {
       if (!token) return
+
+      const shouldRefresh = () => {
+        if (!refreshToken || !expiresAt) return false
+        const now = Date.now()
+        const bufferMs = 5 * 60 * 1000
+        return now + bufferMs >= expiresAt
+      }
+
+      if (shouldRefresh()) {
+        try {
+          const resp = await fetch('/api/auth/refresh', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ refresh_token: refreshToken }),
+          })
+
+          if (resp.ok) {
+            const payload = await resp.json()
+            persistSession({
+              access_token: payload?.access_token || null,
+              refresh_token: payload?.refresh_token || refreshToken,
+              expires_in: payload?.expires_in,
+              expires_at: payload?.expires_at,
+            })
+          } else {
+            throw new Error('refresh failed')
+          }
+        } catch {
+          setUser(null)
+          setStatus('unauthenticated')
+          setToken(null)
+          setRefreshToken(null)
+          setExpiresAt(null)
+          if (typeof window !== 'undefined') {
+            localStorage.removeItem('auth:access_token')
+            localStorage.removeItem('auth:refresh_token')
+            localStorage.removeItem('auth:expires_at')
+          }
+          return
+        }
+      }
+
       try {
         const r = await fetch('/api/auth/user', { headers: { Authorization: `Bearer ${token}` } })
         if (r.ok) {
@@ -57,18 +153,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         } else {
           setUser(null)
           setStatus('unauthenticated')
-          if (typeof window !== 'undefined') localStorage.removeItem('auth:access_token')
+          if (typeof window !== 'undefined') {
+            localStorage.removeItem('auth:access_token')
+            localStorage.removeItem('auth:refresh_token')
+            localStorage.removeItem('auth:expires_at')
+          }
           setToken(null)
+          setRefreshToken(null)
+          setExpiresAt(null)
         }
       } catch {
         setUser(null)
         setStatus('unauthenticated')
-        if (typeof window !== 'undefined') localStorage.removeItem('auth:access_token')
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('auth:access_token')
+          localStorage.removeItem('auth:refresh_token')
+          localStorage.removeItem('auth:expires_at')
+        }
         setToken(null)
+        setRefreshToken(null)
+        setExpiresAt(null)
       }
     }
     verify()
-  }, [token])
+  }, [token, refreshToken, expiresAt])
 
   const login = async () => {
     const r = await fetch('/api/auth/start')
@@ -81,7 +189,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUser(null)
     setToken(null)
     setStatus('unauthenticated')
-    if (typeof window !== 'undefined') localStorage.removeItem('auth:access_token')
+    setRefreshToken(null)
+    setExpiresAt(null)
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('auth:access_token')
+      localStorage.removeItem('auth:refresh_token')
+      localStorage.removeItem('auth:expires_at')
+    }
   }
 
   const headers = (): Record<string, string> =>

--- a/components/dashboard/boardpage.tsx
+++ b/components/dashboard/boardpage.tsx
@@ -7,10 +7,13 @@ import { DatasetItemsList } from '@/components/dataset-items-list'
 import { ExportModal } from '@/components/export-modal'
 import { GroupsSection } from '@/components/groups-section'
 import { LoadingState } from '@/components/loading-state'
+import { useAuth } from '@/components/auth-context'
+import { Button } from '@/components/ui/button'
 import ImportControls from './ImportControls'
 import { useDatasetDashboard } from './useDatasetDashboard'
 
 export default function DashboardPage() {
+  const { logout } = useAuth()
   const {
     // data
     items, analytics, loading,
@@ -36,6 +39,11 @@ export default function DashboardPage() {
 
   return (
     <div className="container mx-auto p-6 space-y-6">
+      <div className="flex justify-end">
+        <Button variant="outline" onClick={logout}>
+          Log out
+        </Button>
+      </div>
       {/* Export modal */}
       <ExportModal
         isOpen={isExportModalOpen}


### PR DESCRIPTION
## Summary
- add Supabase token refresh endpoint and allow it through public API access
- persist access/refresh tokens on the client and automatically refresh sessions to keep users logged in
- add a logout button on the dashboard homepage for explicit sign out

## Testing
- npm run lint *(fails: missing `next/typescript` ESLint config in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c2a60e3c8333bbe1322833e0801c)