### PR TITLE
Keep unsaved warning when save fails

### DIFF
--- a/components/ReviewItemHooks.ts
+++ b/components/ReviewItemHooks.ts
@@ -213,7 +213,12 @@ export function useReviewItem(id: string, router: any) {
       })
     });
     const payload = await res.json().catch(() => null);
-    if (!res.ok || payload?.success !== true) return null;
+    const ok =
+      res.ok &&
+      payload?.success === true &&
+      payload?.dataset &&
+      payload?.versionId;
+    if (!ok) return null;
 
     // Mirror dataset row (already in response) to local state/cache
     if (payload.dataset) {


### PR DESCRIPTION
## Summary
- stop atomic saves from clearing the unsaved flag implicitly
- only clear the unsaved changes indicator after confirming a successful save response
- ensure stamping flow preserves unsaved warning when the save call fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69262b41fb20833396782ad7d65e530c)